### PR TITLE
fix: adjust dynamic route handler params for Next.js 15

### DIFF
--- a/src/app/api/admin/scans/[id]/route.ts
+++ b/src/app/api/admin/scans/[id]/route.ts
@@ -10,7 +10,10 @@ interface ScanDoc {
   hits?: unknown[];
 }
 
-export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
+export async function GET(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+) {
   try {
     const { db } = initFirebaseAdmin();
 
@@ -23,7 +26,8 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
       );
     await getAuth().verifyIdToken(token);
 
-    const snap = await db.collection('scans').doc(ctx.params.id).get();
+    const { id } = await ctx.params;
+    const snap = await db.collection('scans').doc(id).get();
     if (!snap.exists)
       return NextResponse.json(
         { ok: false, error: 'NOT_FOUND' },

--- a/src/app/api/kis/intraday/[symbol]/route.ts
+++ b/src/app/api/kis/intraday/[symbol]/route.ts
@@ -11,9 +11,9 @@ import { KIS_BASE_URL, ENV } from '@/lib/env';
  */
 export async function GET(
   req: NextRequest,
-  ctx: { params: { symbol: string } }
+  ctx: { params: Promise<{ symbol: string }> }
 ) {
-  const symbol = ctx.params.symbol;
+  const { symbol } = await ctx.params;
   const { searchParams } = new URL(req.url);
   const mrkt = searchParams.get('mrkt') || 'J';
   const trId = searchParams.get('tr_id') || 'FHKST03010200'; // 문서 확인 필요

--- a/src/app/api/kis/price/[symbol]/route.ts
+++ b/src/app/api/kis/price/[symbol]/route.ts
@@ -13,9 +13,9 @@ import { KIS_BASE_URL, ENV } from '@/lib/env';
  */
 export async function GET(
   req: NextRequest,
-  ctx: { params: { symbol: string } }
+  ctx: { params: Promise<{ symbol: string }> }
 ) {
-  const symbol = ctx.params.symbol;
+  const { symbol } = await ctx.params;
   const { searchParams } = new URL(req.url);
   const mrkt = searchParams.get('mrkt') || 'J';
   const trId = searchParams.get('tr_id') || 'FHKST01010100'; // 문서 TR_ID에 맞게 조정


### PR DESCRIPTION
## Summary
- adapt dynamic route handlers to Next.js 15 `RouteContext` signature
- await `params` before using dynamic values

## Testing
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a60c114832483f3a53f740692c9